### PR TITLE
Fix README header formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # personal-organizer
+
 My own personal organizer, intended to run on my Raspberry Pi and be accessible from any of my devices.


### PR DESCRIPTION
## Summary
- add missing blank line after README title for proper Markdown rendering

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab3553ef4083288ecc5ad9020e04a4